### PR TITLE
Removed unnecessary job dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ on:
 
 jobs:
   publish-npm:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,9 @@
 ##### Autobuild
 
 * Added husky to autobuild the package pre-commit and push.
+
+### 1.1.1 (2022-09-28)
+
+##### Removed job dependency on `main` branch github workflow
+
+* Removed job dependency on `main` branch github workflow.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/safle-keyless-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "engines": {
     "node": ">=12.22.9"


### PR DESCRIPTION
Removed non-existent job dependency on the `main` branch workflow which was causing the workflow to error out.